### PR TITLE
[Baseline] - Cite the fixture commit in the baseline provenance

### DIFF
--- a/baseline/README.md
+++ b/baseline/README.md
@@ -19,13 +19,18 @@ Where the two disagree, the screenshots are the accurate record of the app.
 | Field | Value |
 |---|---|
 | RTL app version | 0.15.8-beta (`shahanafarooqui/rtl:v0.15.8`) |
-| RTL app commit | `6a01e96c` (`master`), plus the fixture password fix from PR #1623 |
 | Node implementation | LND 0.20.0-beta (`polarlightning/lnd:0.20.0-beta`) |
 | Backend | Bitcoin Core 30.0 (`polarlightning/bitcoind:30.0`) |
 | Network | regtest |
 | Capture date | 2026-07-16 |
-| Fixture | RTL repo, `docker/` — see its README |
+| Fixture | RTL repo at commit `1a6cb0b0`, directory `docker/` |
 | Capture harness | `capture/` in this folder |
+
+The fixture commit is the reproducibility anchor: `docker/` at `1a6cb0b0` was
+verified byte-identical to the tree these screenshots were captured against.
+Check out that commit, run the fixture and the harness, and you get this state
+back. The RTL, LND and bitcoind versions above are pinned inside that commit's
+`docker-compose.yml` rather than being incidental to the machine that ran it.
 
 ## Capture conditions
 


### PR DESCRIPTION
Small accuracy fix to the baseline provenance, ahead of tagging v1.0.

## The problem

`baseline/README.md` cited the fixture as:

> RTL app commit | `6a01e96c` (`master`), plus the fixture password fix from PR #1623

That described a *pending state* rather than a checkoutable one, and it's now stale — the fix has merged. A tagged snapshot's provenance should point at something you can check out and run.

## The fix

Cites the RTL repo at commit **`1a6cb0b0`**, verified byte-identical under `docker/` to the tree these screenshots were captured against. Check out that commit, run the fixture and `capture/`, and you get this state back. The RTL, LND and bitcoind versions are pinned inside that commit's `docker-compose.yml`, so they're properties of the fixture rather than of the machine that happened to run it.

## Worth knowing

The password fix landed across **two** PRs, not one. Ride-The-Lightning/RTL#1623 was squash-merged with only the first of its two commits — GitHub reports `commits=1` — which left `.env` correct while `seed.sh` still printed the blacklisted `password`, telling users to log in with the one value that bounces them to a forced password change. Ride-The-Lightning/RTL#1624 re-landed the remainder.

That's why the citation is `1a6cb0b0` and not the merge commit of #1623: only the later commit reproduces the captured state. I found it by diffing `docker/` between capture-time and merged `master` while checking whether the citation would be honest — the PR page itself gives no hint that half of it went missing.
